### PR TITLE
Add Travis based deployment to the ImageJ update site

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: java
+sudo: false
+jfk: oraclejk8
+
+script: ./travis-deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,8 @@ language: java
 sudo: false
 jfk: oraclejk8
 
-script: ./travis-deploy.sh
+deploy:
+  provider: script
+  script: ./travis-deploy.sh
+  on:
+    branch: master

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
   <artifactId>dependency_copy</artifactId>
 
   <properties>
-    <fiji.home>/Applications/Fiji.app</fiji.home>
-    <bioformats.version>5.4.1</bioformats.version>
+    <fiji.home>Fiji.app</fiji.home>
+    <bioformats.version>5.5.0-SNAPSHOT</bioformats.version>
   </properties>
 
   <dependencies>

--- a/travis-deploy.sh
+++ b/travis-deploy.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env sh
+set -e
+
+export WEBDAV_USER="Sbesson"
+export UPDATE_SITE="Sbesson"
+
+# Define some variables 
+export IJ_PATH="$HOME/Fiji.app"
+export URL="http://sites.imagej.net/$UPDATE_SITE/"
+export IJ_LAUNCHER="$IJ_PATH/ImageJ-linux64"
+export PATH="$IJ_PATH:$PATH"
+
+# Install ImageJ
+mkdir -p $IJ_PATH/
+cd $HOME/
+wget --no-check-certificate https://downloads.imagej.net/fiji/latest/fiji-linux64.zip
+unzip fiji-linux64.zip
+$IJ_LAUNCHER --update update-force-pristine
+
+# Install the package
+cd $TRAVIS_BUILD_DIR/
+mvn clean package -Dfiji.home=$IJ_PATH
+
+# Deploy the package
+$IJ_LAUNCHER --update edit-update-site $UPDATE_SITE $URL "webdav:$WEBDAV_USER:$WIKI_UPLOAD_PASS" .
+$IJ_LAUNCHER --update upload-complete-site --force-shadow $UPDATE_SITE


### PR DESCRIPTION
See https://trello.com/c/6d660y63/9-fiji-update-site-investigate-automation-and-maintenance

This PR sets up Travis on this organization repository and includes a deployment step (for merged PRs only) which upload new JARs to an Image update site following the strategy described in http://imagej.net/Automatic_Update_Site_Uploads#Automatic_Uploads_via_Travis_CI.

At the moment, the script and the secret password have been configured to use my [personal update site](http://sites.imagej.net/Sbesson). See https://travis-ci.org/openmicroscopy/bio-formats-fiji/builds/227634720 for the build log and https://travis-ci.org/openmicroscopy/bio-formats-fiji/builds/227654154 to show that the deployment is idempotent if nothing has changed.

To test this output of this PR, in a Fiji distribution, activate the personal update site update, update and restart Fiji then check that Bio-Formats ships the 5.5.0-SNAPSHOT version.

Once accepted and reviewed, the update site name and credentials will be updated to deploy JARs to the [Bio-Formats update site](http://sites.imagej.net/Bio-Formats/). 