### PR TITLE
Bio-Formats update site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-bio-formats-fiji
+Bio-Formats Fiji
 ================
+
+[![Build Status](https://travis-ci.org/openmicroscopy/bio-formats-fiji.svg)](https://travis-ci.org/openmicroscopy/bio-formats-fiji)
 
 A simple POM allowing to update a Fiji distribution with a new version of
 Bio-Formats.

--- a/travis-deploy.sh
+++ b/travis-deploy.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env sh
 set -e
 
-export WEBDAV_USER="Sbesson"
-export UPDATE_SITE="Sbesson"
+export WEBDAV_USER="Bio-Formats"
+export UPDATE_SITE="Bio-Formats"
 
 # Define some variables 
 export IJ_PATH="$HOME/Fiji.app"


### PR DESCRIPTION
Following #1, this PR adds the Travis status to the Readme and switches the deployment steps to point to the Bio-Formats update site. I will update the secret environment variable stored in the Travis configuration accordingly.

Apart from a general check, there is not much to test as deployment is only happening on merge. Once done, the http://sites.imagej.net/Bio-Formats/ update site should contain the latest 5.5.0-SNAPSHOT.
