### PR TITLE
Bump Bio-Formats to 5.5.1 SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <properties>
     <fiji.home>Fiji.app</fiji.home>
-    <bioformats.version>5.5.0-SNAPSHOT</bioformats.version>
+    <bioformats.version>5.5.0</bioformats.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <properties>
     <fiji.home>Fiji.app</fiji.home>
-    <bioformats.version>5.5.0</bioformats.version>
+    <bioformats.version>5.5.1-SNAPSHOT</bioformats.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
c3472cd has been used to update the [Fiji update site](http://sites.imagej.net/Fiji) with the 5.5.0 artifacts

Check that Travis is green. Once merged, this PR will switch to deploy the 5.5.1-SNAPSHOT JARs to the [Bio-Formats update site](http://sites.imagej.net/Bio-Formats/].