### PR TITLE
Bump version to 5.5.2 SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <properties>
     <fiji.home>Fiji.app</fiji.home>
-    <bioformats.version>5.5.1-SNAPSHOT</bioformats.version>
+    <bioformats.version>5.5.1</bioformats.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <properties>
     <fiji.home>Fiji.app</fiji.home>
-    <bioformats.version>5.5.1</bioformats.version>
+    <bioformats.version>5.5.2-SNAPSHOT</bioformats.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Following 5.5.1 release, 2db2b90 has been used to update manually the Java-8 update site and the second commit should bump the SNAPSHOT deployed to the Bio-Formats update site to 5.5.2-SNAPSHOT