### PR TITLE
Bump BIo-Formats version to 5.6.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <properties>
     <fiji.home>Fiji.app</fiji.home>
-    <bioformats.version>5.5.3</bioformats.version>
+    <bioformats.version>5.6.0-SNAPSHOT</bioformats.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <properties>
     <fiji.home>Fiji.app</fiji.home>
-    <bioformats.version>5.5.3-SNAPSHOT</bioformats.version>
+    <bioformats.version>5.5.3</bioformats.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
c0f3fe5 was used to deploy the release on the Java-8 update site.