### PR TITLE
Bump bioformats.version to 5.6.1-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <properties>
     <fiji.home>Fiji.app</fiji.home>
-    <bioformats.version>5.6.1</bioformats.version>
+    <bioformats.version>5.6.1-SNAPSHOT</bioformats.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <properties>
     <fiji.home>Fiji.app</fiji.home>
-    <bioformats.version>5.6.0-SNAPSHOT</bioformats.version>
+    <bioformats.version>5.6.1</bioformats.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Also includes c9bf89f which was used to bump the Java8 update site.

To test this PR, check Travis is green.

 
