### PR TITLE
Bump Bio-Formats to 5.7.3 SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ Additional two properties can be overriden and passed as `-Dkey=value` to
 the command above:
 
 - `fiji.home` specified the root directory of the Fiji application (default: `Applications/Fiji.app`)
-- `bioformats.verison` specifies the new version of Bio-Formats to replace into the Fiji distribution
+- `bioformats.version` specifies the new version of Bio-Formats to replace into the Fiji distribution

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <properties>
     <fiji.home>Fiji.app</fiji.home>
-    <bioformats.version>5.7.2-SNAPSHOT</bioformats.version>
+    <bioformats.version>5.7.2</bioformats.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -79,12 +79,12 @@
     <repository>
       <id>ome</id>
       <name>Bio-Formats Repo</name>
-      <url>http://artifacts.openmicroscopy.org/artifactory/maven</url>
+      <url>https://artifacts.openmicroscopy.org/artifactory/maven</url>
     </repository>
     <repository>
       <id>unidata</id>
       <name>Unidata Repository</name>
-      <url>http://artifacts.unidata.ucar.edu/content/repositories/unidata-releases</url>
+      <url>https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases</url>
     </repository>
   </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <properties>
     <fiji.home>Fiji.app</fiji.home>
-    <bioformats.version>5.7.2</bioformats.version>
+    <bioformats.version>5.7.3-SNAPSHOT</bioformats.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
- Bump to 5.7.2 (c8162da) for deployment to the Java8 update site
- Fix typo in README
- Use HTTPS for artifacts URls
- Bump to 5.7.3-SNAPSHOT to populate the Bio-Formats update site