### PR TITLE
6.13.0 Rebuild

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -3,6 +3,8 @@
 name: Maven
 
 on:
+  pull_request:
+
   push:
     branches:
       - master
@@ -19,7 +21,15 @@ jobs:
         with:
           java-version: 8
           distribution: 'zulu'
+
       - name: Deploy
         run: ./deploy.sh
         env:
           WIKI_UPLOAD_PASS: ${{ secrets.BF_WIKI_UPLOAD_PASS }}
+        if: github.event_name != 'pull_request'
+
+      - name: Test
+        run: ./deploy.sh
+        env:
+          SKIPDEPLOY: "true"
+        if: github.event_name == 'pull_request'

--- a/deploy.sh
+++ b/deploy.sh
@@ -30,6 +30,11 @@ fi
 mvn clean package -Dfiji.home="$IJ_PATH"
 
 # Deploy the package
-export PATH="$IJ_PATH:$PATH"
-"$IJ_LAUNCHER" --update edit-update-site "$UPDATE_SITE" "$URL" "$LOGIN" "$DIR"
-"$IJ_LAUNCHER" --update upload-complete-site --force-shadow "$UPDATE_SITE"
+if [ -z ${SKIPDEPLOY+x} ];
+then
+    export PATH="$IJ_PATH:$PATH"
+    "$IJ_LAUNCHER" --update edit-update-site "$UPDATE_SITE" "$URL" "$LOGIN" "$DIR"
+    "$IJ_LAUNCHER" --update upload-complete-site --force-shadow "$UPDATE_SITE"
+else
+    echo "Skipping deploy..."
+fi

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <repository>
       <id>unidata</id>
       <name>Unidata Repository</name>
-      <url>https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases</url>
+      <url>https://artifacts.unidata.ucar.edu/repository/unidata-releases/</url>
     </repository>
   </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>ome</groupId>
-  <version>6.13.1-SNAPSHOT</version>
+  <version>6.13.1</version>
   <artifactId>dependency_copy</artifactId>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <properties>
     <fiji.home>Fiji.app</fiji.home>
-    <bioformats.version>6.13.1-SNAPSHOT</bioformats.version>
+    <bioformats.version>6.13.0</bioformats.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
* [x] Rollback to 6.13.0 (non-SNAPSHOT)
* [x] Update unidata URL
----

A local build of the main branch on this repo passed. Rolling back to the 6.13.0 release version failed with:

```
[ERROR] Failed to execute goal on project dependency_copy: Could not resolve dependencies for project ome:dependency_copy:jar:6.13.1-SNAPSHOT: Could not transfer artifact edu.ucar:httpservices:jar:5.3.3 from/to unidata (https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases): transfer failed for https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/httpservices/5.3.3/httpservices-5.3.3.jar: peer not authenticated -> [Help 1]
```

Updating the repository URL allowed the build to pass again.