### PR TITLE
Exclude OMEZarrReader from being copied to plugins folder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
             </goals>
             <configuration>
               <excludeTransitive>true</excludeTransitive>
+              <excludeArtifactIds>OMEZarrReader</excludeArtifactIds>
               <outputDirectory>${fiji.home}/plugins</outputDirectory>
             </configuration>
           </execution>


### PR DESCRIPTION
Currently the OMEZarrReader jar is copied to both the `plugins` folder and the `jars/bioformats` folder. With this PR it will now only appear in `jars/bioformats` as expected.